### PR TITLE
add keep/drop

### DIFF
--- a/spec/rollable/dice.cr
+++ b/spec/rollable/dice.cr
@@ -119,6 +119,14 @@ describe Rollable::Dice do
       d6dh2.test.should be <= d6dh2.max
       d6dh2.test.should be >= d6dh2.min
     end
+
+    it "correctly calculated the average" do
+      # source: https://math.stackexchange.com/a/223248
+      Rollable::Dice.parse("2d6kh1").average.round(3).should eq 4.472
+      # source: http://onlinedungeonmaster.com/2012/05/24/advantage-and-disadvantage-in-dd-next-the-math/
+      Rollable::Dice.parse("2d20d1").average.round(3).should eq 13.825
+      Rollable::Dice.parse("2d20dh1").average.round(3).should eq 7.175
+    end
   end
 
   it "parse (error)" do

--- a/spec/rollable/dice.cr
+++ b/spec/rollable/dice.cr
@@ -65,8 +65,17 @@ describe Rollable::Dice do
       Rollable::Dice.parse("4d6kl1").min.should eq 1
       Rollable::Dice.parse("4d6kl1").max.should eq 6
 
-      # What are thoughts on this value? Maybe expose count_after_drop?
-      # Rollable::Dice.parse("4d6kl1").count.should eq 1
+      Rollable::Dice.parse("4d6kl1").count_after_drop.should eq 1
+    end
+
+    it "rolls keep dice within bounds" do
+      d6kl1 = Rollable::Dice.parse("4d6kl1")
+      d6kl1.test.should be <= d6kl1.max
+      d6kl1.test.should be >= d6kl1.min
+
+      d6kh2 = Rollable::Dice.parse("4d6kh2")
+      d6kh2.test.should be <= d6kh2.max
+      d6kh2.test.should be >= d6kh2.min
     end
 
     it "parses drop" do
@@ -87,8 +96,17 @@ describe Rollable::Dice do
       Rollable::Dice.parse("4d6dl1").min.should eq 3
       Rollable::Dice.parse("4d6dl1").max.should eq 18
 
-      # What are thoughts on this value? Maybe expose count_after_drop?
-      # Rollable::Dice.parse("4d6dl1").count.should eq 3
+      Rollable::Dice.parse("4d6dl1").count_after_drop.should eq 3
+    end
+
+    it "rolls drop dice within bounds" do
+      d6dl1 = Rollable::Dice.parse("4d6dl1")
+      d6dl1.test.should be <= d6dl1.max
+      d6dl1.test.should be >= d6dl1.min
+
+      d6dh2 = Rollable::Dice.parse("4d6dh2")
+      d6dh2.test.should be <= d6dh2.max
+      d6dh2.test.should be >= d6dh2.min
     end
   end
 

--- a/spec/rollable/dice.cr
+++ b/spec/rollable/dice.cr
@@ -47,6 +47,17 @@ describe Rollable::Dice do
   end
 
   describe "adjustements" do
+    it "initialize" do 
+      d = Rollable::Dice.new 2, 20, false, 1
+      d.should be_a Rollable::Dice
+      d.min.should eq 1
+      d.max.should eq 20
+      d = Rollable::Dice.new 2, 20, false, -1
+      d.should be_a Rollable::Dice
+      d.min.should eq 1
+      d.max.should eq 20
+    end
+
     it "parses keep" do
       Rollable::Dice.parse("2d6k1").should be_a(Rollable::Dice)
       Rollable::Dice.parse("2d6k1").min.should eq 1

--- a/spec/rollable/dice.cr
+++ b/spec/rollable/dice.cr
@@ -46,6 +46,52 @@ describe Rollable::Dice do
     Rollable::Dice.parse("!1d6").max.should eq Rollable::Die.new(1..6, true).max
   end
 
+  describe "adjustements" do
+    it "parses keep" do
+      Rollable::Dice.parse("2d6k1").should be_a(Rollable::Dice)
+      Rollable::Dice.parse("2d6k1").min.should eq 1
+      Rollable::Dice.parse("2d6k1").max.should eq 6
+      Rollable::Dice.parse("3d6k1").min.should eq 1
+      Rollable::Dice.parse("3d6k1").max.should eq 6
+
+      Rollable::Dice.parse("3d6k2").min.should eq 2
+      Rollable::Dice.parse("3d6k2").max.should eq 12
+      Rollable::Dice.parse("3d6k0").min.should eq 0
+      Rollable::Dice.parse("3d6k0").max.should eq 0 
+
+      Rollable::Dice.parse("4d6kh1").min.should eq 1
+      Rollable::Dice.parse("4d6kh1").max.should eq 6
+
+      Rollable::Dice.parse("4d6kl1").min.should eq 1
+      Rollable::Dice.parse("4d6kl1").max.should eq 6
+
+      # What are thoughts on this value? Maybe expose count_after_drop?
+      # Rollable::Dice.parse("4d6kl1").count.should eq 1
+    end
+
+    it "parses drop" do
+      Rollable::Dice.parse("2d6d1").should be_a(Rollable::Dice)
+      Rollable::Dice.parse("2d6d1").min.should eq 1
+      Rollable::Dice.parse("2d6d1").max.should eq 6
+      Rollable::Dice.parse("3d6d1").min.should eq 2
+      Rollable::Dice.parse("3d6d1").max.should eq 12
+
+      Rollable::Dice.parse("3d6d2").min.should eq 1
+      Rollable::Dice.parse("3d6d2").max.should eq 6
+      Rollable::Dice.parse("3d6d3").min.should eq 0
+      Rollable::Dice.parse("3d6d3").max.should eq 0 
+
+      Rollable::Dice.parse("4d6dh1").min.should eq 3
+      Rollable::Dice.parse("4d6dh1").max.should eq 18
+
+      Rollable::Dice.parse("4d6dl1").min.should eq 3
+      Rollable::Dice.parse("4d6dl1").max.should eq 18
+
+      # What are thoughts on this value? Maybe expose count_after_drop?
+      # Rollable::Dice.parse("4d6dl1").count.should eq 3
+    end
+  end
+
   it "parse (error)" do
     expect_raises(Exception) { Rollable::Dice.parse("yolo") }
     expect_raises(Exception) { Rollable::Dice.parse("1d6+1", true) }

--- a/src/rollable/dice.cr
+++ b/src/rollable/dice.cr
@@ -111,7 +111,21 @@ class Rollable::Dice < Rollable::IsRollable
   end
 
   def average : Float64
-    @die.average * @count
+    if drop == 0
+      @die.average * @count
+    else
+      # simulate all of the possible rolls
+      rolls = (1..@count).reduce([] of Int32) { |rolls, x| rolls.concat(1..@die.size).to_a }
+      # grab unique combinations
+      uniq_rolls = rolls.combinations(count).uniq
+      # sum all combinations(following drop logic) then divide to get average
+      uniq_rolls.reduce(0){ |sum, roll| 
+        roll.sort!
+        roll.reverse! if drop > 0
+        roll.shift(drop.abs)
+        sum + roll.sum
+      } / uniq_rolls.size
+    end
   end
 
   def average_details : Array(Float64)

--- a/src/rollable/dice.cr
+++ b/src/rollable/dice.cr
@@ -47,7 +47,7 @@ class Rollable::Dice < Rollable::IsRollable
     self
   end
 
-  private def count_after_drop
+  def count_after_drop
     @count - @drop.abs
   end
 
@@ -90,7 +90,10 @@ class Rollable::Dice < Rollable::IsRollable
 
   # Roll an amount of `Dice` as specified, and return the sum
   def test : Int32
-    @count.times.reduce(0) { |r, l| r + @die.test }
+    rolls = test_details
+    rolls.reverse! if @drop > 0
+    rolls.shift(@drop.abs)
+    rolls.reduce(0) { |r, l| r + l }
   end
 
   # Roll an amount of `Dice` as specified, and return the values

--- a/src/rollable/dice.cr
+++ b/src/rollable/dice.cr
@@ -90,7 +90,7 @@ class Rollable::Dice < Rollable::IsRollable
 
   # Roll an amount of `Dice` as specified, and return the sum
   def test : Int32
-    rolls = test_details
+    rolls = test_details.sort
     rolls.reverse! if @drop > 0
     rolls.shift(@drop.abs)
     rolls.reduce(0) { |r, l| r + l }

--- a/src/rollable/dice.cr
+++ b/src/rollable/dice.cr
@@ -101,6 +101,15 @@ class Rollable::Dice < Rollable::IsRollable
     @count.times.to_a.map { @die.test }
   end
 
+  # Roll an amount of `Dice` as specified, and return the values along with the
+  # values that would be dropped
+  def test_details_with_drop : {Array(Int32), Array(Int32)}
+    rolls = @count.times.to_a.map { @die.test }.sort
+    rolls_to_drop = @drop < 0 ? rolls.reverse : rolls.clone
+    rolls_to_drop.shift(@count - @drop.abs)
+    {rolls, rolls_to_drop}
+  end
+
   def average : Float64
     @die.average * @count
   end

--- a/src/rollable/dice/parse_wrap.cr
+++ b/src/rollable/dice/parse_wrap.cr
@@ -10,16 +10,34 @@ class Rollable::Dice
   # - If "strict" is false, then the string doesn't have to finish following
   #   the regexp.
   private def self.parse_string(str : String, strict = true) : NamedTuple(str: String, dice: Dice)
-    match = str.match(/\A(?<sign>-|\+)? *(?<exploding>!)?(?<count>\d+)(?:(?:d)(?<die>\d+))?#{strict ? "\\Z" : ""}/i)
+    match = str.match(/\A(?<sign>-|\+)? *(?<exploding>!)?(?<count>\d+)(?:(?:d)(?<die>\d+))?(?<adjustment>[k|d][l|h]?\d+)?#{strict ? "\\Z" : ""}/i)
     raise ParsingError.new("Parsing Error: dice, near to '#{str}'") if match.nil?
     sign = (match["sign"]? || "+") == "+" ? 1 : -1
     count = match["count"]
     die = match["die"]?
     exploding = match["exploding"]? ? true : false
+    drop = match["adjustment"]? ? parse_adjustment(match["adjustment"], count.to_i) : 0
     if die.nil?
       {str: match[0], dice: FixedValue.new_dice(sign * count.to_i)}
     else
-      {str: match[0], dice: Dice.new(sign * count.to_i, die.to_i, exploding)}
+      {str: match[0], dice: Dice.new(sign * count.to_i, die.to_i, exploding, drop)}
+    end
+  end
+
+  # Return the drop value of parsed string
+  # Negative means "lowest", positive means "highest"
+  # Normalized to be "drop" so:
+  # keep lowest X becomes drop highest Y
+  # keep highest X becomes drop lowest Y
+  private def self.parse_adjustment(str : String, count : Int32) :  Int32
+    match = str.match(/(?<kind>[k|d])(?<type>[l|h])?(?<quantity>\d+)/i)
+    return 0 if match.nil?
+    quantity = match["kind"] === "k" ? count - match["quantity"].to_i : match["quantity"].to_i
+    case match["type"]?
+    when "h"
+      match["kind"] === "k" ? quantity * -1 : quantity
+    else
+      match["kind"] === "k" ? quantity : quantity * -1
     end
   end
 


### PR DESCRIPTION
Didn't get as much time as I'd like but here's the start of the implementation. Few things to note:

~~**This doesn't actually drop any dice in `test` yet.** Wanted to get the parsing + most easily testable methods done first and it's too late for me to do the math for this lol. I'll hopefully have time tomorrow or Sunday to finish this up.~~

I set it up such that `Dice` can understand what it means to `drop` any number of dice from its roll. This means `keep` is translated into `drop` before being given to `Dice`.

Not sure how it makes sense to think about `count` with `keep`/`drop`. Private to `Dice` I added a `count_after_drop`, maybe I should just make this public. What do you think?
